### PR TITLE
fix(activities): Activities - Adding sound in the instruction input doesn't work(MEF-2722)

### DIFF
--- a/cg-file-upload-worker.js
+++ b/cg-file-upload-worker.js
@@ -30,7 +30,7 @@ this.onmessage = function(e) {
   while (start < size) {
     blobs.push(file.slice(start, end));
     start = end;
-    end = start + bytes_per_chunk;
+    end = start += bytes_per_chunk;
   }
   for (i = j = 0, len = blobs.length; j < len; i = ++j) {
     blob = blobs[i];

--- a/cg-file-upload.js
+++ b/cg-file-upload.js
@@ -408,7 +408,7 @@ angular.module('cg.fileupload').factory('cgFileUploadCtrl', function($timeout, $
       this._size = (file.size / Math.pow(1024, 2)).toFixed(2);
       this._mimetype = file.type;
       _originalFilename = file.name;
-      _filename = this._normalizeName(file.name);
+      _filename = file.name;
       if (typeof this.onUploadStart === "function") {
         this.onUploadStart({
           size: this._size,


### PR DESCRIPTION
Greg asked me to change File name which was (1213154 -  title song) to name only 

When a file was around 10mo or more, it was downloaded twice, one part and other part because of (bytes_per_chunk limited to 1024 x 1024 x  10) the result was big part of sound remove from it and  the other one add, the file was only 8sec instead of 4:30. Here I kept the first part, add the second one. 